### PR TITLE
fix bug - error message in josn upload movies

### DIFF
--- a/src/components/movies/import-movies-json-dialog.tsx
+++ b/src/components/movies/import-movies-json-dialog.tsx
@@ -70,6 +70,7 @@ const ImportMoviesJson = ({ children }: ImportMoviesJsonProps) => {
         toast.error(error?.response?.data.message ?? 'Something went wrong', {
           classNames: {
             toast: '!bg-feedback-error',
+            title: '!line-clamp-3',
           },
         });
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the error toast title in the Import Movies JSON dialog by limiting it to three lines. This prevents overly long titles from overflowing or disrupting the layout, especially on smaller screens. Users will see cleaner, more readable error messages with consistent spacing. No changes to behavior or error handling—only visual enhancement to maintain a tidy, predictable interface when import errors include lengthy titles or descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->