### PR TITLE
Dev - upadte tv-show data types

### DIFF
--- a/src/components/tv-show/tv-show-table.tsx
+++ b/src/components/tv-show/tv-show-table.tsx
@@ -123,7 +123,7 @@ export const tvShowColumns: ColumnDef<
     ),
   },
   {
-    accessorKey: 'runTime',
+    accessorKey: 'avgRunTime',
     header: 'Runtime',
     cell: (props) => (
       <p className="text-base-white text-base">

--- a/src/services/tv-episode-service.ts
+++ b/src/services/tv-episode-service.ts
@@ -12,6 +12,8 @@ export type EpisodeBase = {
   episodeNumber: number;
   releaseDate?: string;
   runTime: number;
+  stillUrl?: string;
+  averageRating?: number;
   createdAt: string;
   updatedAt: string;
   season: string;

--- a/src/services/tv-season-service.ts
+++ b/src/services/tv-season-service.ts
@@ -12,10 +12,12 @@ export type SeasonBase = {
   releaseDate: string;
   seasonRating?: number;
   status: string;
-  trailerYoutubeUrl?: string;
+  youtubeVideoId?: string;
+  noOfEpisodes: number;
+  tvShow: string;
+  averageRating?: number;
   createdAt: string;
   updatedAt: string;
-  tvShow: string;
 };
 
 export type SeasonFull = SeasonBase & {

--- a/src/services/tv-show-service.ts
+++ b/src/services/tv-show-service.ts
@@ -20,7 +20,7 @@ export type TvShowBase = {
   genre: string[];
   cast?: string[];
   directors?: string[];
-  runTime: number;
+  avgRunTime?: number;
   languages?: string[];
   posterUrl?: string;
   backdropUrl?: string;
@@ -30,6 +30,9 @@ export type TvShowBase = {
   ageRating?: number;
   totalSeasons: number;
   totalEpisodes: number;
+  youtubeVideoId?: string;
+  tmdbId?: string;
+  imdbId?: string;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TV show tables now display average runtime.
  * Episodes can show still images and average ratings (where available).
  * Seasons display the number of episodes and average ratings.
  * Season video support updated to use YouTube video IDs for improved playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->